### PR TITLE
Fixed broken `bish` script in install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ by their initials (`time-series` --> `ts`).
 
 #### Examples
 
-`bish period trace ts osc scale-map vco mul -v 0.05 trace speaker`
+`bish period trace ts osc scale-map vco mul -c 0.05 trace speaker`
 
 TODO(#13)
 

--- a/hcm/bish
+++ b/hcm/bish
@@ -6,7 +6,7 @@ import click
 import rx
 
 import hcm
-from hcm import types
+from hcm import types, synth
 
 SAMPLE_RATE = 8000  # hz
 INTERVAL_LENGTH = 1000  # ms

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy
 scipy
 rx==1.6.1
 sounddevice
-click
+click<8.1.0

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,5 @@ setup(
         'dev': [x.strip() for x in open('dev_requirements.txt', 'r').readlines()]
     },
     packages=find_packages(),
-    scripts=['bin/bish']
+    scripts=['hcm/bish']
 )


### PR DESCRIPTION
pip install was broken because there was a missing script. This fixes that error, and makes sure that `bish` works.
Mentions: @alxrsngrtn @jbdoar
